### PR TITLE
Fix the author links on the jobs page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'jekyll'
 gem 'jekyll-seo-tag'
 gem 'jekyll-feed'
 gem 'jekyll-sitemap'
+gem 'jekyll-liquify'
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 
 gem 'dbml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,9 @@ GEM
       terminal-table (~> 2.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-liquify (0.0.2)
+      liquid (>= 2.5, < 5.0)
+      redcarpet (~> 3.1)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.7.1)
@@ -58,6 +61,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     rexml (3.2.5)
     rouge (3.26.0)
     rsec (1.0.0)
@@ -77,6 +81,7 @@ DEPENDENCIES
   dbml
   jekyll
   jekyll-feed
+  jekyll-liquify
   jekyll-seo-tag
   jekyll-sitemap
   webrick

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ plugins:
 - jekyll-seo-tag
 - jekyll-feed
 - jekyll-sitemap
+- jekyll-liquify
 
 sass:
   style: compressed

--- a/_includes/content.html
+++ b/_includes/content.html
@@ -1,2 +1,2 @@
 {% assign main = include.page %}{% unless main and main != empty %}{% assign main = include %}{% endunless %}
-{{ main.content | markdownify }}
+{{ main.content | markdownify | liquify}}


### PR DESCRIPTION
The template content for the jobs page contains liquid template tags, to render links to Andy and Simon's author page, but unfortunately these are not interpreted by default, and the links are broken.

This PR installs jekyll-liquify, a filter plugin which allows for template tags to be processed.

Unfortunately this will not work on github pages as it doesn't allow plugins.